### PR TITLE
feat: Implement mock DB for ADK agents and refine registration

### DIFF
--- a/apps/web/src/lib/adk-agent-db-mock.ts
+++ b/apps/web/src/lib/adk-agent-db-mock.ts
@@ -1,0 +1,100 @@
+import { AdkAgentStoredData } from '../types/adk-agent';
+import { v4 as uuidv4 } from 'uuid';
+
+let adkAgentsStore: AdkAgentStoredData[] = [];
+
+// Helper for deep copying to simulate immutability of a real DB
+function deepCopy<T>(obj: T): T {
+  return JSON.parse(JSON.stringify(obj));
+}
+
+/**
+ * Retrieves all ADK agents from the in-memory store.
+ * @returns A promise that resolves to an array of all ADK agents (deep copies).
+ */
+export async function getAllAdkAgents(): Promise<AdkAgentStoredData[]> {
+  return Promise.resolve(deepCopy(adkAgentsStore));
+}
+
+/**
+ * Retrieves a specific ADK agent by its ID.
+ * @param id The ID of the agent to retrieve.
+ * @returns A promise that resolves to the agent data (deep copy) or null if not found.
+ */
+export async function getAdkAgentById(id: string): Promise<AdkAgentStoredData | null> {
+  const agent = adkAgentsStore.find(a => a.id === id);
+  return Promise.resolve(agent ? deepCopy(agent) : null);
+}
+
+/**
+ * Creates a new ADK agent and adds it to the store.
+ * @param data The data for the new agent, excluding id, createdAt, and updatedAt.
+ * @returns A promise that resolves to the newly created agent data (deep copy).
+ */
+export async function createAdkAgent(
+  data: Omit<AdkAgentStoredData, 'id' | 'createdAt' | 'updatedAt'>
+): Promise<AdkAgentStoredData> {
+  const now = new Date().toISOString();
+  const newAgent: AdkAgentStoredData = {
+    ...data,
+    id: uuidv4(),
+    createdAt: now,
+    updatedAt: now,
+  };
+  adkAgentsStore.push(newAgent);
+  return Promise.resolve(deepCopy(newAgent));
+}
+
+/**
+ * Updates an existing ADK agent by its ID.
+ * @param id The ID of the agent to update.
+ * @param updates Partial data to update the agent with.
+ * @returns A promise that resolves to the updated agent data (deep copy) or null if not found.
+ */
+export async function updateAdkAgent(
+  id: string,
+  updates: Partial<Omit<AdkAgentStoredData, 'id' | 'createdAt' | 'updatedAt'>>
+): Promise<AdkAgentStoredData | null> {
+  const agentIndex = adkAgentsStore.findIndex(a => a.id === id);
+  if (agentIndex === -1) {
+    return Promise.resolve(null);
+  }
+
+  const updatedAgent = {
+    ...adkAgentsStore[agentIndex],
+    ...updates,
+    updatedAt: new Date().toISOString(),
+  };
+  adkAgentsStore[agentIndex] = updatedAgent;
+  return Promise.resolve(deepCopy(updatedAgent));
+}
+
+/**
+ * Deletes an ADK agent by its ID.
+ * @param id The ID of the agent to delete.
+ * @returns A promise that resolves to true if deletion was successful, false otherwise.
+ */
+export async function deleteAdkAgent(id: string): Promise<boolean> {
+  const initialLength = adkAgentsStore.length;
+  adkAgentsStore = adkAgentsStore.filter(a => a.id !== id);
+  return Promise.resolve(adkAgentsStore.length < initialLength);
+}
+
+/**
+ * Clears all agents from the in-memory store. Useful for testing.
+ * @returns A promise that resolves when the store is cleared.
+ */
+export async function clearAdkAgentsStore(): Promise<void> {
+  adkAgentsStore = [];
+  return Promise.resolve();
+}
+
+/**
+ * Seeds the store with initial data. Useful for testing.
+ * @param agents An array of AdkAgentStoredData to seed the store with.
+ * @returns A promise that resolves when the store is seeded.
+ */
+export async function seedAdkAgentsStore(agents: AdkAgentStoredData[]): Promise<void> {
+    adkAgentsStore = deepCopy(agents);
+    return Promise.resolve();
+}


### PR DESCRIPTION
This commit introduces an in-memory mock database for managing ADK agent registrations and integrates it into the backend API routes. It also refines the agent registration process to include fetching and basic validation of the Agent Card.

Key changes:

1.  **Mock Database Service (`apps/web/src/lib/adk-agent-db-mock.ts`):**
    *   Created an in-memory store for `AdkAgentStoredData`.
    *   Implemented CRUD functions (`getAllAdkAgents`, `getAdkAgentById`, `createAdkAgent`, `updateAdkAgent`, `deleteAdkAgent`) and utility functions for seeding/clearing data for testing.

2.  **API Route Integration:**
    *   Modified `apps/web/src/app/api/adk-agents/route.ts` and `apps/web/src/app/api/adk-agents/[agentId]/route.ts`.
    *   All API handlers (GET list, POST create, GET by ID, PUT update, DELETE by ID) now use the `adk-agent-db-mock.ts` service for data persistence, replacing previous placeholder logic.

3.  **Refined Agent Card Fetching in Registration:**
    *   The `POST /api/adk-agents` (registration) endpoint now uses `a2aClientService.fetchAgentCard()` to attempt a live fetch of the ADK agent's Agent Card using its base URL.
    *   Includes basic validation for essential fields in the fetched Agent Card.
    *   If fetching or validation fails, the registration returns a 400 error.
    *   The fetched (or mock, if initial fetch fails but is handled gracefully by client service for testing) Agent Card is stored in the mock database record.

This completes the planned work to establish a functional (though mock-persisted) backend for ADK agent registration and lays the groundwork for more robust testing and UI development.